### PR TITLE
suggests learning objectives as statement of need in paper.md requirements

### DIFF
--- a/app/views/content/github/_learning_module_review_checklist.erb
+++ b/app/views/content/github/_learning_module_review_checklist.erb
@@ -31,5 +31,5 @@
 ### JOSE paper
 
 - [ ] **Authors:** Does the `paper.md` file include a list of authors with their affiliations?
-- [ ] **A statement of need:** Do the authors clearly state the need for this module and who the target audience is?
+- [ ] **A statement of need:** Do the authors clearly state the learning outcomes this module achieves and who the target audience is?
 - [ ] **References:** Do all archival references that should have a DOI list one (e.g., papers, datasets, software)?


### PR DESCRIPTION
One minor thought : I wonder if guiding the authors toward using learning outcomes to describe the "need" for the learning module would be helpful (to both authors and reviewers).  Although we stop short of explicitly requiring learning objectives in the modules, requesting a summary in the form of learning outcomes seems to me like the most straightforward and universal way to describe "need" for a module.

