### PR TITLE
Improved clarity of open-source educational materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ JOSE publishes two types of (brief) articles that describe:
 
  1. open-source educational materials
 
- 2. open educational software tools
+ 2. open-source educational software tools
 
  ### Why is this journal needed?
 
@@ -22,18 +22,18 @@ JOSE publishes two types of (brief) articles that describe:
  ### What do you mean by "open-source educational materials"?
 
  "Open-source" implies that there are source files that are converted and
- rendered into a final learner-presentable form of the content. Examples
- include Jupyter notebooks or plaintext/markup language documents like LaTeX,
- Markdown, ReStructuredText, AsciiDoc, and R Markdown. These documents should
- embody both course/lesson content and associated instructor notes. Lastly, the
- course content should make use of computation for learning with embedded or
- associated code snippets/programs.
+ rendered into a final learner-presentable form. Examples include Jupyter
+ notebooks or plaintext/markup language documents like LaTeX, Markdown,
+ ReStructuredText, AsciiDoc, and R Markdown. These documents should contain the
+ lesson content and be designed to be reusable by other instructors.  Lastly,
+ the course content should make use of computation for learning with embedded
+ or associated code snippets/programs.
 
  We do **not** mean openly available slides, lecture notes, or YouTube videos, though these may be acceptable as supplementary materials. In addition, course syllabi by themselves are not suitable for submission ([*Syllabus*](http://syllabusjournal.org/) may be more appropriate).
 
  tl;dr: your course or lesson content must contain or use code to teach. We are not focused exclusively on learning to code, but coding to learn.
 
- ### What do you mean by "educational software tools"?
+ ### What do you mean by "open-source educational software tools"?
 
  Open-source software that serves as educational technology; examples include (but are not limited to) alternatives to learning management systems, autograders, cloud systems for lesson delivery, student collaboration tools. For these tools, peer review will follow a similar process as [JOSS](http://joss.theoj.org/about#reviewer_guidelines).
 

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ JOSE relies on the journal management infrastructure and tools developed for JOS
 
 JOSE publishes two types of (brief) articles that describe:
 
- 1. open educational software tools
+ 1. open-source educational materials
 
- 2. open-source learning modules
+ 2. open educational software tools
 
  ### Why is this journal needed?
 
@@ -21,7 +21,13 @@ JOSE publishes two types of (brief) articles that describe:
 
  ### What do you mean by "open-source educational materials"?
 
- Examples include Jupyter notebooks or plaintext/markup language documents like LaTeX, R Markdown, and ReST for course/lesson content and associated notes, with embedded or associated code snippets/programs.
+ "Open-source" implies that there are source files that are converted and
+ rendered into a final learner-presentable form of the content. Examples
+ include Jupyter notebooks or plaintext/markup language documents like LaTeX,
+ Markdown, ReStructuredText, AsciiDoc, and R Markdown. These documents should
+ embody both course/lesson content and associated instructor notes. Lastly, the
+ course content should make use of computation for learning with embedded or
+ associated code snippets/programs.
 
  We do **not** mean openly available slides, lecture notes, or YouTube videos, though these may be acceptable as supplementary materials. In addition, course syllabi by themselves are not suitable for submission ([*Syllabus*](http://syllabusjournal.org/) may be more appropriate).
 

--- a/app/views/content/about/_general.html.erb
+++ b/app/views/content/about/_general.html.erb
@@ -1,15 +1,15 @@
 <p>
   JOSE, pronounced [hoe-zay], is a sibling journal to the
   <a href="http://joss.theoj.org/" target="_blank">Journal of Open Source Software</a>
-  (JOSS), which publishes open research software. JOSE relies on the journal management
-  infrastructure and tools developed for JOSS.
+  (JOSS), which publishes open-source research software. JOSE relies on the
+  journal management infrastructure and tools developed for JOSS.
 </p>
 
 <p>
   JOSE publishes two types of articles that describe:
   <ul>
       <li>open-source educational materials</li>
-      <li>open educational software tools</li>
+      <li>open-source educational software tools</li>
   </ul>
 </p>
 
@@ -36,12 +36,12 @@
 <h3>What do you mean by "open-source educational materials"?</h3>
 <p>
   "Open-source" implies that there are source files that are converted and
-  rendered into a final learner-presentable form of the content. Examples
-  include Jupyter notebooks or plaintext/markup language documents like LaTeX,
-  Markdown, ReStructuredText, AsciiDoc, and R Markdown. These documents should
-  embody both course/lesson content and associated instructor notes. Lastly,
-  the course content should make use of computation for learning with embedded
-  or associated code snippets/programs.
+  rendered into a final learner-presentable form. Examples include Jupyter
+  notebooks or plaintext/markup language documents like LaTeX, Markdown,
+  ReStructuredText, AsciiDoc, and R Markdown. These documents should contain
+  the lesson content and be designed to be reusable by other instructors.
+  Lastly, the course content should make use of computation for learning with
+  embedded or associated code snippets/programs.
 </p>
 
 <p>

--- a/app/views/content/about/_general.html.erb
+++ b/app/views/content/about/_general.html.erb
@@ -8,15 +8,15 @@
 <p>
   JOSE publishes two types of articles that describe:
   <ul>
+      <li>open-source educational materials</li>
       <li>open educational software tools</li>
-      <li>open-source learning modules</li>
   </ul>
 </p>
 
 <h3>Why is this journal needed?</h3>
 <p>
   Currently, academia lacks a mechanism for crediting efforts to develop software for
-  assisting teaching and learning or open-source educational content.
+  assisting teaching and learning or open-source educational content and materials.
   As a result, beyond personal motivation, there is little incentive to develop and share such material.
 </p>
 
@@ -35,8 +35,12 @@
 
 <h3>What do you mean by "open-source educational materials"?</h3>
 <p>
-  Examples include Jupyter notebooks or plaintext/markup language documents like LaTeX,
-  R Markdown, and ReST for course/lesson content and associated notes, with embedded
+  "Open-source" implies that there are source files that are converted and
+  rendered into a final learner-presentable form of the content. Examples
+  include Jupyter notebooks or plaintext/markup language documents like LaTeX,
+  Markdown, ReStructuredText, AsciiDoc, and R Markdown. These documents should
+  embody both course/lesson content and associated instructor notes. Lastly,
+  the course content should make use of computation for learning with embedded
   or associated code snippets/programs.
 </p>
 

--- a/app/views/content/about/_submission_flow.html.erb
+++ b/app/views/content/about/_submission_flow.html.erb
@@ -6,9 +6,9 @@
 <h2>The two submission types</h2>
 
 <p>
-  JOSE accepts two types of submissions: (1) computational learning modules, created
-  as open educational resources (OER), and (2) open-source software, created as
-  educational technology or infrastructure.
+  JOSE accepts two types of submissions: (1) computational learning modules,
+  created as open-source educational materials, and (2) open-source software,
+  created as educational technology or infrastructure.
 </p>
 
 <h3 id="submission_requirements">Submission requirements</h3>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,7 @@
 # Changing this file necessitates a server restart
 name: "The Journal of Open Source Education"
 abbreviation: "JOSE"
-tagline: "an <strong>educator friendly</strong> journal for publishing computational learning modules and educational software."
+tagline: "an <strong>educator friendly</strong> journal for publishing open-source educational materials and software."
 logo_url: "http://jose.theoj.org/logo_large.png"
 url: "http://jose.theoj.org"
 editor_email: "jose.theoj@gmail.com"
@@ -17,5 +17,5 @@ reviewers: "https://bit.ly/jose-reviewers"
 submission_enquiry: |-
   **Project repository URL:** INSERT YOUR REPOSITORY LINK HERE
 
-  Briefly describe your educational module or software, and any questions you have about the JOSE submission criteria.
+  Briefly describe your educational materials or software, and any questions you have about the JOSE submission criteria.
 paper_types: ['software', 'learning module']


### PR DESCRIPTION
- I swapped the order of the submission types to 1) match the order of
  the explanations below and 2) to make the content type more primary.
- I replaced "open-source learning modules" with "open-source educational
  materials" to make the documents consistent and only use one term.
- I expanded the definition of "open-source educational materials"
  with an attempt to be more clear and specific (because I'm still
  confused what the original wording meant).