### PR TITLE
Add footnote to example paper

### DIFF
--- a/app/views/content/about/_paper_contents.html.erb
+++ b/app/views/content/about/_paper_contents.html.erb
@@ -76,6 +76,8 @@ This is an example citation [@figshare_archive].
 
 Figures can be included like this: ![Fidgit deposited in figshare.](figshare_article.png)
 
+A footnote can be inserted like this^[This is a footnote.].
+
 # References
 </pre>
 


### PR DESCRIPTION
This pull request adds a footnote to the example `paper.md` file on the JOSE about page as originally mentioned in #28.