### PR TITLE
Underscores on about page

### DIFF
--- a/app/views/content/about/_paper_contents.html.erb
+++ b/app/views/content/about/_paper_contents.html.erb
@@ -5,7 +5,7 @@
 <ol>
   <li>List all authors and affiliations.</li>
   <li>Describe the submission, and explain its eligibility for JOSE.</li>
-  <li>Include a _Statement of Need_, explaining how the submitted 
+  <li>Include a <i>Statement of Need</i>, explaining how the submitted 
     artifacts contribute to computationally enabled teaching and learning, and describing how they 
     might be adopted by others.</li>
   <li>For software submissions, describe the functionality of the software, usage and 


### PR DESCRIPTION
On the JOSE about page there are a couple of underscores which appear to be markdown formatting that, I assume, was never changed to HTML.